### PR TITLE
Porter v0.21.1

### DIFF
--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 }
 
 group = "in.porter.exposed"
-version = "0.21.2"
+version = "0.21.1"
 
 val sourceJar = task("sourceJar", Jar::class) {
     dependsOn(JavaPlugin.CLASSES_TASK_NAME)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -39,7 +39,9 @@ class ThreadLocalTransactionManager(private val db: Database,
         private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) {
             outerTransaction?.connection ?: db.connector().apply {
                 autoCommit = false
-                transactionIsolation = this@ThreadLocalTransaction.transactionIsolation
+                if (this@ThreadLocalTransaction.transactionIsolation != IGNORE_ISOLATION_LEVEL) {
+                    transactionIsolation = this@ThreadLocalTransaction.transactionIsolation
+                }
             }
         }
         override val connection: ExposedConnection<*>

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -25,6 +25,7 @@ interface TransactionInterface {
 }
 
 const val DEFAULT_ISOLATION_LEVEL = Connection.TRANSACTION_REPEATABLE_READ
+const val IGNORE_ISOLATION_LEVEL = -1
 
 const val DEFAULT_REPETITION_ATTEMPTS = 3
 


### PR DESCRIPTION
Add support for `IGNORE_ISOLATION_LEVEL` - in which case exposed does not attempt to set the isolation level of the transaction after acquiring a connection.