### PR TITLE
v0.21.1.1

### DIFF
--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 }
 
 group = "in.porter.exposed"
-version = "0.21.1"
+version = "0.21.2"
 
 val sourceJar = task("sourceJar", Jar::class) {
     dependsOn(JavaPlugin.CLASSES_TASK_NAME)


### PR DESCRIPTION
Added support for `continueSuspendedTransaction` which checks if there is already a Transaction in scope. If yes, then use `Transaction.suspendedTransaction`, else `newSuspendedTransaction`.